### PR TITLE
Fix nkro on some operating systems

### DIFF
--- a/main/usb/usb_descriptors.c
+++ b/main/usb/usb_descriptors.c
@@ -59,12 +59,12 @@ uint32_t usb_polling_rate = 0;
         HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE )  ,\
     HID_USAGE_PAGE ( HID_USAGE_PAGE_KEYBOARD ) ,\
         HID_USAGE_MIN    ( 0                                   )  ,\
-        HID_USAGE_MAX    ( (AMK_NKRO_TOTAL_SIZE-2)*8             )  ,\
+        HID_USAGE_MAX    ( (AMK_NKRO_TOTAL_SIZE-2)*8-1         )  ,\
         HID_LOGICAL_MIN  ( 0                                   )  ,\
         HID_LOGICAL_MAX  ( 1                                   )  ,\
         HID_REPORT_COUNT ( (AMK_NKRO_TOTAL_SIZE-2)*8             )  ,\
         HID_REPORT_SIZE  ( 1                                   )  ,\
-        HID_INPUT        ( HID_DATA | HID_ARRAY | HID_ABSOLUTE )  ,\
+        HID_INPUT        ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE )  ,\
     HID_COLLECTION_END
 
 #define VIAL_USAGE_PAGE     0xFF60


### PR DESCRIPTION
The NKRO descriptor was previously not correct. The correct type is HID_VARIABLE and USAGE_MAX could never get hit with the report count.

Prior to these changes, NKRO wouldn't work on Linux and `hid-recorder` would report `ErrorRollOver` in the key report:
```
# ReportID: 4 / LeftControl: 0 | LeftShift: 0 | LeftAlt: 0 | Left GUI: 0 | RightControl: 0 | RightShift: 0 | RightAlt: 0 | Right GUI: 0 |Keyboard ['0x70000', '0x70000', '0x70000', '0x70000', '0x70000', 'ErrorRollOver', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', 'ErrorRollOver', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000', '0x70000']
E: 000160.570650 32 04 00 20 00 00 02 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
```

After this change NKRO works as expected and `hid-recorder` reports normally:
```
# ReportID: 4 / LeftControl: 0 | LeftShift: 0 | LeftAlt: 0 | Left GUI: 0 | RightControl: 0 | RightShift: 0 | RightAlt: 0 | Right GUI: 0 | 0x70000: 0 | ErrorRollOver: 0 | POSTFail: 0 | ErrorUndefine: 0 | a and A: 0 | b and B: 1 | c and C: 0 | d and D: 0 | e and E: 0 | f and F: 0 | g and G: 0 | h and H: 0 | i and I: 0 | j and J: 0 | k and K: 0 | l and L: 0 | m and M: 0 | n and N: 0 | o and O: 0 | p and P: 0 | q and Q: 0 | r and R: 0 | s and S: 0 | t and T: 0 | u and U: 0 | v and V: 0 | w and W: 0 | x and X: 0 | y and Y: 0 | z and Z: 0 | 1 and !: 0 | 2 and @: 0 | 3 and #: 0 | 4 and $: 0 | 5 and %: 0 | 6 and ^: 0 | 7 and &: 0 | 8 and *: 0 | 9 and (: 0 | 0 and ): 0 | Return (ENTER): 0 | ESCAPE: 0 | DELETE (Backspace): 0 | Tab: 0 | Spacebar: 0 | - and (underscore): 0 | = and +: 0 | [ and {: 0 | ] and }: 0 | \ and |: 0 | Non-US # and ~: 0 | ; and :: 0 | ' and ": 0 | Grave Accent and Tilde: 0 | Keyboard, and <: 0 | . and >: 0 | / and ?: 0 | Caps Lock: 0 | F1: 0 | F2: 0 | F3: 0 | F4: 0 | F5: 0 | F6: 0 | F7: 0 | F8: 0 | F9: 0 | F10: 0 | F11: 0 | F12: 0 | PrintScreen: 0 | Scroll Lock: 0 | Pause: 0 | Insert: 0 | Home: 0 | PageUp: 0 | Delete Forward: 0 | End: 0 | PageDown: 0 | RightArrow: 0 | LeftArrow: 0 | DownArrow: 0 | UpArrow: 0 | Keypad Num Lock and Clear: 0 | Keypad /: 0 | Keypad *: 0 | Keypad -: 0 | Keypad +: 0 | Keypad ENTER: 0 | Keypad 1 and End: 0 | Keypad 2 and Down Arrow: 0 | Keypad 3 and PageDn: 0 | Keypad 4 and Left Arrow: 0 | Keypad 5: 0 | Keypad 6 and Right Arrow: 0 | Keypad 7 and Home: 0 | Keypad 8 and Up Arrow: 0 | Keypad 9 and PageUp: 0 | Keypad 0 and Insert: 0 | Keypad . and Delete: 0 | Non-US \ and |: 0 | Application: 0 | Power: 0 | Keypad =: 0 | F13: 0 | F14: 0 | F15: 0 | F16: 0 | F17: 0 | F18: 0 | F19: 0 | F20: 0 | F21: 0 | F22: 0 | F23: 0 | F24: 0 | Execute: 0 | Help: 0 | Menu: 0 | Select: 0 | Stop: 0 | Again: 0 | Undo: 0 | Cut: 0 | Copy: 0 | Paste: 0 | Find: 0 | Mute: 0 | Volume Up: 0 | Volume Down: 0 | Locking Caps Lock: 0 | Locking Num Lock: 0 | Locking Scroll Lock: 0 | Keypad Comma: 0 | Keypad Equal Sign: 0 | Kanji1: 0 | Kanji2: 0 | Kanji3: 0 | Kanji4: 0 | Kanji5: 0 | Kanji6: 0 | Kanji7: 0 | Kanji8: 0 | Kanji9: 0 | LANG1: 0 | LANG2: 0 | LANG3: 0 | LANG4: 0 | LANG5: 0 | LANG6: 0 | LANG7: 0 | LANG8: 0 | LANG9: 0 | Alternate Erase: 0 | SysReq/Attention: 0 | Cancel: 0 | Clear: 0 | Prior: 0 | Return: 0 | Separator: 0 | Out: 0 | Oper: 0 | Clear/Again: 0 | CrSel/Props: 0 | ExSel: 0 | 0x700a5: 0 | 0x700a6: 0 | 0x700a7: 0 | 0x700a8: 0 | 0x700a9: 0 | 0x700aa: 0 | 0x700ab: 0 | 0x700ac: 0 | 0x700ad: 0 | 0x700ae: 0 | 0x700af: 0 | 0x700b0: 0 | 0x700b1: 0 | 0x700b2: 0 | 0x700b3: 0 | 0x700b4: 0 | 0x700b5: 0 | 0x700b6: 0 | 0x700b7: 0 | 0x700b8: 0 | 0x700b9: 0 | 0x700ba: 0 | 0x700bb: 0 | 0x700bc: 0 | 0x700bd: 0 | 0x700be: 0 | 0x700bf: 0 | 0x700c0: 0 | 0x700c1: 0 | 0x700c2: 0 | 0x700c3: 0 | 0x700c4: 0 | 0x700c5: 0 | 0x700c6: 0 | 0x700c7: 0 | 0x700c8: 0 | 0x700c9: 0 | 0x700ca: 0 | 0x700cb: 0 | 0x700cc: 0 | 0x700cd: 0 | 0x700ce: 0 | 0x700cf: 0 | 0x700d0: 0 | 0x700d1: 0 | 0x700d2: 0 | 0x700d3: 0 | 0x700d4: 0 | 0x700d5: 0 | 0x700d6: 0 | 0x700d7: 0 | 0x700d8: 0 | 0x700d9: 0 | 0x700da: 0 | 0x700db: 0 | 0x700dc: 0 | 0x700dd: 0 | 0x700de: 0 | 0x700df: 0 | LeftControl: 0 | LeftShift: 0 | LeftAlt: 0 | Left GUI: 0 | RightControl: 0 | RightShift: 0 | RightAlt: 0 | Right GUI: 0 | 0x700e8: 0 | 0x700e9: 0 | 0x700ea: 0 | 0x700eb: 0 | 0x700ec: 0 | 0x700ed: 0 | 0x700ee: 0 | 0x700ef: 0 
E: 000019.281388 32 04 00 20 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
```